### PR TITLE
Add comprehensive MCP servers and installation script

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,22 @@ A curated list of Model Context Protocol (MCP) servers for global installation w
 
 This repository contains my personal collection of preferred MCP servers that I use globally with Claude Desktop. These servers extend Claude's capabilities by providing access to various tools and services.
 
+## Quick Installation
+
+Run this single command to install all recommended MCP servers:
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/miwidot/claude-mcp/main/install-mcp-servers.sh | bash
+```
+
+Or clone the repository and run locally:
+
+```bash
+git clone https://github.com/miwidot/claude-mcp.git
+cd claude-mcp
+./install-mcp-servers.sh
+```
+
 ## Installation
 
 ### Prerequisites
@@ -61,6 +77,48 @@ Provides persistent memory capabilities across conversations.
 
 ```bash
 npm install -g @modelcontextprotocol/server-memory
+```
+
+### 6. **Sequential Thinking** (`@modelcontextprotocol/server-sequential-thinking`)
+Enables step-by-step reasoning and complex problem-solving capabilities. This server helps Claude break down complex tasks into manageable steps and maintain context throughout multi-stage operations.
+
+```bash
+npm install -g @modelcontextprotocol/server-sequential-thinking
+```
+
+### 7. **Puppeteer Browser Automation** (`@modelcontextprotocol/server-puppeteer`)
+Provides browser automation capabilities using Puppeteer. Perfect for web scraping, automated testing, taking screenshots, and interacting with web applications programmatically.
+
+```bash
+npm install -g @modelcontextprotocol/server-puppeteer
+```
+
+### 8. **Web Fetching** (`@kazuph/mcp-fetch`)
+Simple and efficient web content fetching and extraction. This lightweight server focuses on quickly retrieving and processing web content without the overhead of full browser automation.
+
+```bash
+npm install -g @kazuph/mcp-fetch
+```
+
+### 9. **Playwright Browser Automation** (`@playwright/mcp`)
+Modern browser automation with support for Chrome, Firefox, and Safari. Playwright offers more robust cross-browser testing capabilities and better performance than traditional automation tools.
+
+```bash
+npm install -g @playwright/mcp@latest
+```
+
+### 10. **Context7** (`@upstash/context7-mcp`)
+Provides advanced context management and caching capabilities using Upstash. This server helps maintain conversation context and improves response consistency across multiple interactions.
+
+```bash
+npm install -g @upstash/context7-mcp@latest
+```
+
+### 11. **Xcode Build Helper** (`xcodebuildmcp`)
+Assists with Xcode project building, testing, and iOS development tasks. Essential for iOS/macOS developers, providing direct integration with Xcode's build system and tools.
+
+```bash
+npm install -g xcodebuildmcp@latest
 ```
 
 ## Configuration

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,3 +1,15 @@
+2025-07-28 - Added comprehensive MCP servers and installation script
+- Created install-mcp-servers.sh for one-command installation
+- Added 6 new MCP servers with detailed descriptions:
+  - Sequential Thinking: Step-by-step reasoning capabilities
+  - Puppeteer: Browser automation for web scraping and testing
+  - Web Fetching: Lightweight web content extraction
+  - Playwright: Modern cross-browser automation
+  - Context7: Advanced context management with Upstash
+  - Xcode Build Helper: iOS/macOS development integration
+- Updated README with quick installation instructions
+- Made installation script executable
+
 2025-07-28 - Initial repository creation
 - Created README.md with MCP server list and installation instructions
 - Added .gitignore for common files

--- a/install-mcp-servers.sh
+++ b/install-mcp-servers.sh
@@ -1,0 +1,120 @@
+#!/bin/bash
+
+# Claude MCP Servers Installation Script
+# One-command installation for all preferred MCP servers
+
+set -e
+
+echo "╔════════════════════════════════════════════════════════════════╗"
+echo "║       🚀 Claude Desktop MCP Servers Installation Script        ║"
+echo "╚════════════════════════════════════════════════════════════════╝"
+echo ""
+
+# Check if claude CLI is installed
+if ! command -v claude &> /dev/null; then
+    echo "❌ Error: Claude CLI not found. Please install Claude CLI first."
+    echo "Visit: https://docs.anthropic.com/en/docs/claude-code"
+    exit 1
+fi
+
+# Function to install an MCP server with error handling
+install_mcp() {
+    local name=$1
+    local description=$2
+    shift 2
+    local command=("$@")
+    
+    echo ""
+    echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+    echo "📦 Installing: $name"
+    echo "📝 Description: $description"
+    echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+    
+    if claude mcp add "$@" 2>/dev/null; then
+        echo "✅ Successfully installed $name"
+    else
+        echo "⚠️  Warning: Failed to install $name (might already be installed)"
+    fi
+}
+
+# Install Sequential Thinking MCP
+install_mcp "Sequential Thinking" \
+    "Enables step-by-step reasoning and complex problem-solving capabilities" \
+    sequential-thinking -s user -- npx -y @modelcontextprotocol/server-sequential-thinking
+
+# Install Puppeteer MCP
+install_mcp "Puppeteer Browser Automation" \
+    "Provides browser automation for web scraping, testing, and interaction" \
+    puppeteer -s user -- npx -y @modelcontextprotocol/server-puppeteer
+
+# Install Web Fetching MCP
+install_mcp "Web Fetching (kazuph)" \
+    "Simple and efficient web content fetching and extraction" \
+    fetch -s user -- npx -y @kazuph/mcp-fetch
+
+# Install Playwright MCP
+install_mcp "Playwright Browser Automation" \
+    "Modern browser automation with support for Chrome, Firefox, and Safari" \
+    playwright npx @playwright/mcp@latest
+
+# Install Context7 MCP
+install_mcp "Context7 (Upstash)" \
+    "Provides context management and caching capabilities using Upstash" \
+    context7 -- npx -y @upstash/context7-mcp@latest
+
+# Install Xcode Build Helper MCP
+install_mcp "Xcode Build Helper" \
+    "Assists with Xcode project building, testing, and iOS development tasks" \
+    xc -- npx -y xcodebuildmcp@latest
+
+# Additional recommended servers from the original list
+echo ""
+echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+echo "📦 Installing additional recommended servers..."
+echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+
+# Install File System MCP
+install_mcp "File System Operations" \
+    "Read, write, and manage files on your local system" \
+    filesystem -s user -- npx -y @modelcontextprotocol/server-filesystem
+
+# Install Git MCP
+install_mcp "Git Version Control" \
+    "Execute Git commands and manage repositories" \
+    git -s user -- npx -y @modelcontextprotocol/server-git
+
+# Install GitHub MCP (requires token)
+echo ""
+echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+echo "📦 GitHub MCP (requires configuration)"
+echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+echo "⚠️  Note: GitHub MCP requires a personal access token"
+echo "   Please set GITHUB_PERSONAL_ACCESS_TOKEN environment variable"
+echo "   or configure it manually in Claude Desktop settings"
+
+# Install Memory MCP
+install_mcp "Memory Management" \
+    "Persistent memory and context retention across conversations" \
+    memory -s user -- npx -y @modelcontextprotocol/server-memory
+
+# Verify installation
+echo ""
+echo "╔════════════════════════════════════════════════════════════════╗"
+echo "║                    ✅ Installation Summary                     ║"
+echo "╚════════════════════════════════════════════════════════════════╝"
+echo ""
+echo "📋 Listing all installed MCP servers:"
+echo ""
+claude mcp list
+
+echo ""
+echo "🎉 MCP servers installation completed!"
+echo ""
+echo "📝 Additional Notes:"
+echo "   • Some servers may require additional configuration"
+echo "   • Check each server's documentation for advanced features"
+echo "   • Restart Claude Desktop to ensure all servers are loaded"
+echo ""
+echo "📚 For more information, visit:"
+echo "   https://github.com/miwidot/claude-mcp"
+echo ""


### PR DESCRIPTION
## Summary
- Created `install-mcp-servers.sh` for one-command installation of all MCP servers
- Added 6 new MCP servers with detailed descriptions
- Updated README with quick installation instructions via curl or local execution

## New MCP Servers Added
1. **Sequential Thinking** - Step-by-step reasoning and complex problem-solving
2. **Puppeteer** - Browser automation for web scraping and testing
3. **Web Fetching** - Lightweight web content extraction
4. **Playwright** - Modern cross-browser automation with multi-browser support
5. **Context7** - Advanced context management using Upstash
6. **Xcode Build Helper** - iOS/macOS development integration

## Test plan
- [x] Installation script created with proper error handling
- [x] Script made executable
- [x] README updated with installation instructions
- [x] All MCP servers documented with descriptions
- [ ] Script tested locally (requires Claude CLI)